### PR TITLE
Fix window not defined if running on server side

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-const root = window.document;
-
 function trimString(string, length) {
   return string && string.length > length ?
     string.substring(0, length) + "..." :
@@ -17,7 +15,7 @@ function connectToDevTools(componentName) {
   return devTools;
 }
 
-root.addEventListener("SvelteRegisterComponent", (e) => {
+typeof window !== "undefined" && window.document.addEventListener("SvelteRegisterComponent", (e) => {
   let send = true;
 
   let {component, tagName, options} = e.detail;


### PR DESCRIPTION
# Issue

Currently, `svelte-watch` breaks on SSR frameworks like Sapper, due to `window` not being defined in the Node.js environment.

# Fix
Check for the existence of `window` before attaching the event listener.